### PR TITLE
Fix major bugs with _printf.c

### DIFF
--- a/_printf.c
+++ b/_printf.c
@@ -67,10 +67,12 @@ int print_arg(va_list list, int index, const char *format, int tmp)
 
 	index--;
 	(void)useless;
-	for (; format[index] != ' '; index++)
+	for (; format[index] != ' ' && format[index] != '\0'; index++)
 	{
 		tmp = tmp + 1;
 		_putchar(format[index]);
+		if (format[index + 1] == '%')
+		    break;
 	}
 	return (tmp);
 }

--- a/tests/main.c
+++ b/tests/main.c
@@ -7,6 +7,12 @@ int main(void)
 	char *stest = "TEST";
 
 	/* %d and %i test */
-	_printf("no1: %d no2: %% string: %s\n", DTEST, "yes", stest);
+	_printf("no1: %d\n", DTEST);
+	_printf("no2: %i\n", ITEST);
+	_printf("no3: %s\n", stest);
+	_printf("no4: %c\n", 'c');
+	_printf("no5: %%\n");
+	_printf("-----------------------\n");
+	_printf("no1: %d\nno2: %i\nno3: %s\nno4: %c\nno5: %%\n", DTEST, ITEST, stest, 'c');
 	return 0;
 }


### PR DESCRIPTION
Fixed bug when a flag is null terminated that would result in printing garbage characters

Add handling for % flag

Rewrite of main.c test file to be more verbose and test for single and multiple arguments passed